### PR TITLE
feat(lex): add whitespace check between interval literal and alias

### DIFF
--- a/zetasql/parser/flex_tokenizer.l
+++ b/zetasql/parser/flex_tokenizer.l
@@ -727,6 +727,12 @@ zone { return BisonParserImpl::token::KW_ZONE; }
 {decimal_digits}[SMHD] {
   return BisonParserImpl::token::INTERVAL_LITERAL;
 }
+{decimal_digits}[SMHD][A-Z_] {
+  yylloc->begin.column += YYLeng() - 1;
+  SetOverrideError(
+      *yylloc, "Syntax error: Missing whitespace between literal and alias");
+  yyterminate();
+}
  /* Error rules for a number followed by an identifier without white space in
     between. We don't want to parse the identifier as accidental alias. For
     instance, 123abc should be error, and we don't want it to be parsed as

--- a/zetasql/parser/testdata/literals.test
+++ b/zetasql/parser/testdata/literals.test
@@ -60,6 +60,20 @@ SELECT
   1d
 ==
 
+select 100ss
+--
+ERROR: Syntax error: Missing whitespace between literal and alias [at 1:12]
+select 100ss
+           ^
+==
+
+select 100DD
+--
+ERROR: Syntax error: Missing whitespace between literal and alias [at 1:12]
+select 100DD
+           ^
+==
+
 select 1e10, .1e10, 0.1e10, 1.e10, 1e+10, .1e-10, 0.1e+10, 1.e-10;
 --
 QueryStatement [0-65]


### PR DESCRIPTION
fix 4paradigm/OpenMLDB#1208

so `select 100ss` will treat as error, not `select 100s as s`