### PR TITLE
ci(macos): build with python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  target: '//zetasql/parser/...'
-  build_argv: '--features=-supports_dynamic_linker '
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   centos-build:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/aceforeverd/hybridsql-base:0.4.0
-    env:
-      BAZEL_LINKOPTS: '-static-libstdc++:-lm'
-      BAZEL_LINKLIBS: '-l%:libstdc++.a'
-      build_argv: '--features=-supports_dynamic_linker '
     steps:
       - uses: actions/checkout@v2
 
@@ -79,7 +71,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'adopt' # See 'Supported distributions' for available options
           java-version: '8'
@@ -118,13 +110,17 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 120
     env:
-      build_argv: '--features=-supports_dynamic_linker '
       bazel_version: '3.7.2'
     steps:
       - uses: actions/checkout@v3
 
       - name: update bazel version
         run: echo ${{ env.bazel_version }} > .bazelversion
+
+      - name: setup python3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
 
       - name: install bazelisk
         run: |

--- a/build_zetasql_parser.sh
+++ b/build_zetasql_parser.sh
@@ -33,18 +33,20 @@ if [[ $(arch) = 'aarch64' ]]; then
     git apply --verbose aarch64.patch
 fi
 
-TARGET='//zetasql/parser/...'
-BUILD_ARGV='--features=-supports_dynamic_linker'
+echo "build with python: $(python -V), python3: $(python3 -V)"
 
-bazel build "$TARGET" "$BUILD_ARGV"
-bazel test "$TARGET" "$BUILD_ARGV"
+TARGET='//zetasql/parser/...'
+BUILD_ARGV=(--features=-supports_dynamic_linker --sandbox_debug)
+
+bazel build "$TARGET" "${BUILD_ARGV[@]}"
+bazel test "$TARGET" "${BUILD_ARGV[@]}"
 
 # explicitly build dependencies into static library
 bazel clean
-bazel query "deps(//zetasql/parser:parser)" | grep //zetasql | xargs bazel build "$BUILD_ARGV"
-bazel build "@com_googleapis_googleapis//:all" "$BUILD_ARGV"
-bazel query "@com_google_file_based_test_driver//..." | xargs bazel build "$BUILD_ARGV"
-bazel build "@com_googlesource_code_re2//:re2" "$BUILD_ARGV"
+bazel query "deps(//zetasql/parser:parser)" | grep //zetasql | xargs bazel build "${BUILD_ARGV[@]}"
+bazel build "@com_googleapis_googleapis//:all" "${BUILD_ARGV[@]}"
+bazel query "@com_google_file_based_test_driver//..." | xargs bazel build "${BUILD_ARGV[@]}"
+bazel build "@com_googlesource_code_re2//:re2" "${BUILD_ARGV[@]}"
 
 unset BAZEL_LINKLIBS
 unset BAZEL_LINKOPTS


### PR DESCRIPTION
Fix build job on macos, by selecting python 3.9 as default python interrupter.

Build with python 3.10 still got problem and is track via https://github.com/4paradigm/zetasql/pull/43